### PR TITLE
replaced itoa with snprintf & fixed other docs

### DIFF
--- a/conversions/int_to_string.c
+++ b/conversions/int_to_string.c
@@ -1,4 +1,3 @@
-
 /**
  * @file
  * @brief Convert a positive integer to string (non-standard function)
@@ -52,26 +51,26 @@ char *int_to_string(uint16_t value, char *dest, int base)
 static void test()
 {
     const int MAX_SIZE = 100;
-    for (int i = 1; i <= 100; ++i)
-    {
-        char *str1 = (char *)calloc(sizeof(char), MAX_SIZE);
-        char *str2 = (char *)calloc(sizeof(char), MAX_SIZE);
+    char *str1 = (char *)calloc(sizeof(char), MAX_SIZE);
+    char *str2 = (char *)calloc(sizeof(char), MAX_SIZE);
 
+    for (int i = 1; i <= 100; ++i) /* test 100 random numbers */
+    {
         /* Generate value from 0 to 100 */
         int value = rand() % 100;
 
         // assert(strcmp(itoa(value, str1, 2), int_to_string(value, str2, 2)) ==
         //        0);
-        snprintf(str1, MAX_SIZE, "%o", value);
+        snprintf(str1, MAX_SIZE, "%o", value);  //* standard C - to octal */
         assert(strcmp(str1, int_to_string(value, str2, 8)) == 0);
-        snprintf(str1, MAX_SIZE, "%d", value);
+        snprintf(str1, MAX_SIZE, "%d", value); /* standard C - to decimal */
         assert(strcmp(str1, int_to_string(value, str2, 10)) == 0);
-        snprintf(str1, MAX_SIZE, "%x", value);
+        snprintf(str1, MAX_SIZE, "%x", value); /* standard C - to hexadecimal */
         assert(strcmp(str1, int_to_string(value, str2, 16)) == 0);
-
-        free(str1);
-        free(str2);
     }
+
+    free(str1);
+    free(str2);
 }
 
 /** Driver Code */

--- a/conversions/int_to_string.c
+++ b/conversions/int_to_string.c
@@ -1,9 +1,11 @@
 
 /**
  * @file
- * @brief Convert integer to string (non-standard function)
+ * @brief Convert a positive integer to string (non-standard function)
+ * representation.
  */
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,14 +15,15 @@
  * Converts an integer value to a null-terminated string using the specified
  * base and stores the result in the array given by str parameter.
  * @param value Value to be converted to a string.
- * @param dest Array in memory where to store the resulting null-terminated
+ * @param dest pointer to array in memory to store the resulting null-terminated
  * string.
  * @param base Numerical base used to represent the value as a string, between 2
  * and 16, where 10 means decimal base, 16 hexadecimal, 8 octal, and 2 binary.
  * @returns A pointer to the resulting null-terminated string, same as parameter
  * str.
+ * @note The destination array must be pre-allocated by the calling function.
  */
-char *int_to_string(int value, char dest[], int base)
+char *int_to_string(uint16_t value, char *dest, int base)
 {
     const char hex_table[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
@@ -57,14 +60,14 @@ static void test()
         /* Generate value from 0 to 100 */
         int value = rand() % 100;
 
-        assert(strcmp(itoa(value, str1, 2), int_to_string(value, str2, 2)) ==
-               0);
-        assert(strcmp(itoa(value, str1, 8), int_to_string(value, str2, 8)) ==
-               0);
-        assert(strcmp(itoa(value, str1, 10), int_to_string(value, str2, 10)) ==
-               0);
-        assert(strcmp(itoa(value, str1, 16), int_to_string(value, str2, 16)) ==
-               0);
+        // assert(strcmp(itoa(value, str1, 2), int_to_string(value, str2, 2)) ==
+        //        0);
+        snprintf(str1, MAX_SIZE, "%o", value);
+        assert(strcmp(str1, int_to_string(value, str2, 8)) == 0);
+        snprintf(str1, MAX_SIZE, "%d", value);
+        assert(strcmp(str1, int_to_string(value, str2, 10)) == 0);
+        snprintf(str1, MAX_SIZE, "%x", value);
+        assert(strcmp(str1, int_to_string(value, str2, 16)) == 0);
 
         free(str1);
         free(str2);


### PR DESCRIPTION
1. `itoa` is not a C99 standard function. 
2. replaced `itoa` with `snprintf`. 
3. `snprintf` does not convert to binary 😒 
4. updated docs
5. important to note that this algorithm is only valid for `unsigned integers`.